### PR TITLE
Add clear_valence to subset_mol

### DIFF
--- a/rdkit_utilities/rdForceFieldHelpers.py
+++ b/rdkit_utilities/rdForceFieldHelpers.py
@@ -43,6 +43,8 @@ def GetMoleculeForceField(
     -------
     rdkit.Chem.rdForceFieldHelpers.ForceField
     """
+    if mol.GetNumConformers() == 0:
+        raise ValueError("Molecule must have conformers to create a force field")
 
     forcefield = forcefield.upper()
     if forcefield not in RDKIT_FF_NAMES:


### PR DESCRIPTION
## Description

To generate a non-wonky molecule, we may need to clear valences after subsetting a molecule by removing radical electrons, etc.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] TODO 1

## Questions
- [ ] Question1

## Status
- [ ] Ready to go